### PR TITLE
Update README.md mongo init instructions

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -63,11 +63,10 @@ app_setup_block: |
 
   **Make sure you pin your database image version and do not use `latest`, as mongodb does not support automatic upgrades between major versions.**
 
-  If you are using the [official mongodb container](https://hub.docker.com/_/mongo/), you can create your databases using an `init-mongo.js` file with the following contents:
+  If you are using the [official mongodb container](https://hub.docker.com/_/mongo/), you can create your user using an `init-mongo.js` file with the following contents:
 
   ```js
-  db.getSiblingDB("MONGO_DBNAME").createUser({user: "MONGO_USER", pwd: "MONGO_PASS", roles: [{role: "readWrite", db: "MONGO_DBNAME"}]});
-  db.getSiblingDB("MONGO_DBNAME_stat").createUser({user: "MONGO_USER", pwd: "MONGO_PASS", roles: [{role: "readWrite", db: "MONGO_DBNAME_stat"}]});
+  db.getSiblingDB("MONGO_DBNAME").createUser({user: "MONGO_USER", pwd: "MONGO_PASS", roles: [{role: "dbOwner", db: "MONGO_DBNAME"}, {role: "dbOwner", db: "MONGO_DBNAME_stat"}]});
   ```
 
   Being sure to replace the placeholders with the same values you supplied to the Unifi container, and mount it into your *mongodb* container.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-unifi-network-application/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Update the instructions for initializing MongoDB, as the provided instructions led to errors when I followed them.

## Benefits of this PR and context:
closes #12 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- I started by backing up my existing unifi controller, so I could migrate to this new image.
- Pulled tag 7.5.174, `c91e20ea07438`
- Followed provided instructions on creating two mongoDB users, one for the main `unifi` database and one for the `unifi_stats` database. This created two separate users in mongoDB, `unifi.unifi` and `unifi_stats.unifi`, with distinct UUIDs.
- Unifi was able to connect to the `unifi` database in mongo and attempt startup, but produced errors in the unifi server.log, `not authorized on unifi_stat to execute command { listCollections: 1`.
- Updating the `unifi.unifi` user to add `{ 'role': 'readWrite', 'db': 'unifi_stat' }` allows the unifi server to start up successfully, but attempting to import my backup produced a new error in server.log: `not authorized on unifi to execute command { dropDatabase: 1, $db: "unifi"`. Apparently importing a backup requires the ability to drop the database.
- So I updated the roles again, this time using `dbOwner` instead of `readWrite` for both databases, and finally was able to successfully import my backup and run the unifi-network-application image.

## Source / References:
None