### PR TITLE
Add support for Mongo TLS & Atlas

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -41,6 +41,8 @@ opt_param_usage_include_env: true
 opt_param_env_vars:
   - { env_var: "MEM_LIMIT", env_value: "1024", desc: "Optionally change the Java memory limit (in Megabytes). Set to `default` to reset to default" }
   - { env_var: "MEM_STARTUP", env_value: "1024", desc: "Optionally change the Java initial/minimum memory (in Megabytes). Set to `default` to reset to default" }
+  - { env_var: "MONGO_TLS", env_value: "", desc: "Mongodb enable TLS. Only evaluated on first run." }
+  - { env_var: "MONGO_AUTHSOURCE", env_value: "", desc: "Mongodb authSource. For Atlas set to `admin`.Defaults to `MONGO_DBNAME`.Only evaluated on first run." }
 
 opt_param_usage_include_ports: true
 opt_param_ports:
@@ -118,4 +120,5 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "17.10.23:", desc: "Add environment variables for TLS and authSource to support Atlas and new MongoDB versions." }
   - { date: "05.09.23:", desc: "Initial release." }

--- a/root/defaults/system.properties
+++ b/root/defaults/system.properties
@@ -41,6 +41,6 @@
 # unifi.throughput.port=6789
 #
 db.mongo.local=false
-db.mongo.uri=mongodb://~MONGO_USER~:~MONGO_PASS~@~MONGO_HOST~:~MONGO_PORT~/~MONGO_DBNAME~
-statdb.mongo.uri=mongodb://~MONGO_USER~:~MONGO_PASS~@~MONGO_HOST~:~MONGO_PORT~/~MONGO_DBNAME~_stat
+db.mongo.uri=mongodb://~MONGO_USER~:~MONGO_PASS~@~MONGO_HOST~:~MONGO_PORT~/~MONGO_DBNAME~?tls=~MONGO_TLS~&authSource=~MONGO_AUTHSOURCE~
+statdb.mongo.uri=mongodb://~MONGO_USER~:~MONGO_PASS~@~MONGO_HOST~:~MONGO_PORT~/~MONGO_DBNAME~_stat?tls=~MONGO_TLS~&authSource=~MONGO_AUTHSOURCE~
 unifi.db.name=~MONGO_DBNAME~

--- a/root/etc/s6-overlay/s6-rc.d/init-unifi-network-application-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-unifi-network-application-config/run
@@ -29,6 +29,16 @@ if [[ ! -e /config/data/system.properties ]]; then
         sed -i "s/~MONGO_PORT~/${MONGO_PORT}/" /defaults/system.properties
         sed -i "s/~MONGO_DBNAME~/${MONGO_DBNAME}/" /defaults/system.properties
         sed -i "s/~MONGO_PASS~/${MONGO_PASS}/" /defaults/system.properties
+        if [[ "${MONGO_TLS,,}" = "true" ]]; then
+            sed -i "s/~MONGO_TLS~/true/" /defaults/system.properties
+        else
+            sed -i "s/~MONGO_TLS~/false/" /defaults/system.properties
+        fi
+        if [[ -z "${MONGO_AUTHSOURCE}" ]]; then
+            sed -i "s/~MONGO_AUTHSOURCE~/${MONGO_DBNAME}/" /defaults/system.properties
+        else
+            sed -i "s/~MONGO_AUTHSOURCE~/${MONGO_AUTHSOURCE}/" /defaults/system.properties
+        fi
         cp /defaults/system.properties /config/data
     fi
 fi


### PR DESCRIPTION
 - [X] I have read the [contributing](https://github.com/linuxserver/docker-unifi-network-application/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:
I have added flags for TLS (`tls`) and `authSource` to the MongoDB URLs. The TLS flag is set to true depending on the `MONGO_TLS` variable. `authSource` is always set to `admin`.

## Benefits of this PR and context:
This PR will do the following:
* Optionally enable TLS for MongoDB (required for Atlas)
* Fix authentication issues when using Atlas as MongoDB backend due to database name being passed as `defaultauthdb` parameter

## How Has This Been Tested?
I have tested with not defining MONGO_TLS variable and haven't noticed any change in behaviour. It would be good if we could get more volunteers to test. 
My test environment was linux (arm64) docker with Atlas as MongoDB backend.

## Source / References:
https://www.mongodb.com/docs/v4.4/reference/connection-string/
https://stackoverflow.com/questions/38237663/mongo-atlas-connection-authentication-failed-with-custom-databases