### PR TITLE
check for mongodb reachability during init

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-unifi-network-application-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-unifi-network-application-config/run
@@ -23,6 +23,9 @@ if [[ ! -e /config/data/system.properties ]]; then
     if [[ -z "${MONGO_HOST}" ]]; then
         echo "*** No MONGO_HOST set, cannot configure database settings. ***"
         exit 1
+    elif ! nc -w1 "${MONGO_HOST}" ${MONGO_PORT}; then
+        echo "*** Defined MONGO_HOST is not reachable, cannot proceed. ***"
+        exit 1
     else
         sed -i "s/~MONGO_USER~/${MONGO_USER}/" /defaults/system.properties
         sed -i "s/~MONGO_HOST~/${MONGO_HOST}/" /defaults/system.properties


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [ X] I have read the [contributing](https://github.com/linuxserver/docker-unifi-network-application/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
rather than blindly supporting people who have mongo and unifi in different bridges, check for reachability during init and flag in the container logs. exiting at this point will also avoid mucking up mongodb or settings
## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
ease our support burden
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
it hasn't been tested aside from in bash, yolo.

```
root@9e424684da5a:/usr/lib/unifi# MONGO_HOST=purple
root@9e424684da5a:/usr/lib/unifi# if [[ -z  "${MONGO_HOST}" ]]; then echo not set; elif ! nc -w1 "${MONGO_HOST}" ${MONGO_PORT}; then echo $? -- not reached; else echo works; fi
nc: getaddrinfo for host "purple" port 27017: Name or service not known
0 -- not reached
root@9e424684da5a:/usr/lib/unifi# MONGO_HOST=mongodb
root@9e424684da5a:/usr/lib/unifi# MONGO_PORT=27018
root@9e424684da5a:/usr/lib/unifi# if [[ -z  "${MONGO_HOST}" ]]; then echo not set; elif ! nc -w1 "${MONGO_HOST}" ${MONGO_PORT}; then echo $? -- not reached; else echo works; fi
0 -- not reached
root@9e424684da5a:/usr/lib/unifi# MONGO_PORT=27017
root@9e424684da5a:/usr/lib/unifi# if [[ -z  "${MONGO_HOST}" ]]; then echo not set; elif ! nc -w1 "${MONGO_HOST}" ${MONGO_PORT}; then echo $? -- not reached; else echo works; fi
works
root@9e424684da5a:/usr/lib/unifi# unset MONGO_HOST
root@9e424684da5a:/usr/lib/unifi# if [[ -z  "${MONGO_HOST}" ]]; then echo not set; elif ! nc -w1 "${MONGO_HOST}" ${MONGO_PORT}; then echo $? -- not reached; else echo works; fi
not set
```

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
what prompted the thought is https://discord.com/channels/354974912613449730/1163422841161650227