### PR TITLE
Enhance db wait startup check

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-unifi-network-application-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-unifi-network-application-config/run
@@ -23,10 +23,20 @@ if [[ ! -e /config/data/system.properties ]]; then
     if [[ -z "${MONGO_HOST}" ]]; then
         echo "*** No MONGO_HOST set, cannot configure database settings. ***"
         sleep infinity
-    elif ! nc -w1 "${MONGO_HOST}" ${MONGO_PORT} >/dev/null 2>&1; then
-        echo "*** Defined MONGO_HOST is not reachable, cannot proceed. ***"
-        sleep infinity
     else
+        echo "*** Waiting for MONGO_HOST ${MONGO_HOST} to be reachable. ***"
+        DBCOUNT=0
+        while true; do
+            if nc -w1 "${MONGO_HOST}" "${MONGO_PORT}" >/dev/null 2>&1; then
+                break
+            fi
+            DBCOUNT=$((DBCOUNT+1))
+            if [[ ${DBCOUNT} -gt 6 ]]; then
+                echo "*** Defined MONGO_HOST ${MONGO_HOST} is not reachable, cannot proceed. ***"
+                sleep infinity
+            fi
+            sleep 5
+        done
         sed -i "s/~MONGO_USER~/${MONGO_USER}/" /defaults/system.properties
         sed -i "s/~MONGO_HOST~/${MONGO_HOST}/" /defaults/system.properties
         sed -i "s/~MONGO_PORT~/${MONGO_PORT}/" /defaults/system.properties


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-unifi-network-application/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Fix race condition where db container doesn't start fast enough by waiting 30 seconds for the DB to be reachable before sleeping.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
