### PR TITLE
Add README links to MongoDB Connection Strings Docs

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -41,8 +41,8 @@ opt_param_usage_include_env: true
 opt_param_env_vars:
   - { env_var: "MEM_LIMIT", env_value: "1024", desc: "Optionally change the Java memory limit (in Megabytes). Set to `default` to reset to default" }
   - { env_var: "MEM_STARTUP", env_value: "1024", desc: "Optionally change the Java initial/minimum memory (in Megabytes). Set to `default` to reset to default" }
-  - { env_var: "MONGO_TLS", env_value: "", desc: "Mongodb enable TLS. Only evaluated on first run." }
-  - { env_var: "MONGO_AUTHSOURCE", env_value: "", desc: "Mongodb authSource. For Atlas set to `admin`.Defaults to `MONGO_DBNAME`.Only evaluated on first run." }
+  - { env_var: "MONGO_TLS", env_value: "", desc: "Mongodb enable [TLS](https://www.mongodb.com/docs/manual/reference/connection-string/#mongodb-urioption-urioption.tls). Only evaluated on first run." }
+  - { env_var: "MONGO_AUTHSOURCE", env_value: "", desc: "Mongodb [authSource](https://www.mongodb.com/docs/manual/reference/connection-string/#mongodb-urioption-urioption.authSource). For Atlas set to `admin`.Defaults to `MONGO_DBNAME`.Only evaluated on first run." }
 
 opt_param_usage_include_ports: true
 opt_param_ports:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-unifi-network-application/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:

This adds links in the README to MongoDB Connection Strings documentation. This will help the reader understand what these environment variables affect by linking to the MongoDB documentation.

## Benefits of this PR and context:

This will make it easier for the reader to understand what the `MONGO_TLS` and `MONGO_AUTHSOURCE` environment variables do
