### PR TITLE
Update readme-vars.yml

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -72,6 +72,12 @@ app_setup_block: |
   db.getSiblingDB("MONGO_DBNAME_stat").createUser({user: "MONGO_USER", pwd: "MONGO_PASS", roles: [{role: "dbOwner", db: "MONGO_DBNAME_stat"}]});
   ```
 
+  If you are using the Mongo v4 (the latest which does not require AVX):
+
+  ```js
+  db.getSiblingDB("MONGO_DBNAME").createUser({user: "MONGO_USER", pwd: "MONGO_PASS", roles: [{role: "dbOwner", db: "MONGO_DBNAME"}, {role: "dbOwner", db: "MONGO_DBNAME_stat"}]});
+  ```
+
   Being sure to replace the placeholders with the same values you supplied to the Unifi container, and mount it into your *mongodb* container.
 
   For example:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->
fixes #29 in the case that the user is not running mongo v5



------------------------------

 - [ x] I have read the [contributing](https://github.com/linuxserver/docker-unifi-network-application/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
It seems like this line has been changed and then reverted. I theorize that different people have gotten it to work based on the version of mongo that they use

## Benefits of this PR and context:
#29 , #58, #24 are all examples of users being confused, hitting errors around this line

## How Has This Been Tested?
tested on my intel NUC (unable to run mongo k)


