### PR TITLE
Replace placeholers in properties with `envsubst`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ LABEL maintainer="thespad"
 
 # environment settings
 ENV DEBIAN_FRONTEND="noninteractive"
+ENV ENVSUBST_VERSION=v1.4.3
 
 RUN \
   echo "**** install packages ****" && \
@@ -19,7 +20,11 @@ RUN \
     jsvc \
     logrotate \
     openjdk-25-jre-headless \
-    unzip && \
+    unzip \
+    gettext && \
+  curl -L https://github.com/a8m/envsubst/releases/download/${ENVSUBST_VERSION}/envsubst-`uname -s`-`uname -m` -o envsubst && \
+  chmod +x envsubst && \
+  mv envsubst /usr/local/bin && \
   echo "**** install unifi ****" && \
   if [ -z ${UNIFI_VERSION+x} ]; then \
     UNIFI_VERSION=$(curl -sX GET "https://fw-update.ubnt.com/api/firmware-latest?filter=eq~~product~~unifi-controller&filter=eq~~platform~~unix&filter=eq~~channel~~release" \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -11,6 +11,7 @@ LABEL maintainer="thespad"
 
 # environment settings
 ENV DEBIAN_FRONTEND="noninteractive"
+ENV ENVSUBST_VERSION=v1.4.3
 
 RUN \
   echo "**** install packages ****" && \
@@ -19,7 +20,11 @@ RUN \
     jsvc \
     logrotate \
     openjdk-25-jre-headless \
-    unzip && \
+    unzip \
+    gettext && \
+  curl -L https://github.com/a8m/envsubst/releases/download/${ENVSUBST_VERSION}/envsubst-`uname -s`-`uname -m` -o envsubst && \
+  chmod +x envsubst && \
+  mv envsubst /usr/local/bin && \
   echo "**** install unifi ****" && \
   if [ -z ${UNIFI_VERSION+x} ]; then \
     UNIFI_VERSION=$(curl -sX GET "https://fw-update.ubnt.com/api/firmware-latest?filter=eq~~product~~unifi-controller&filter=eq~~platform~~unix&filter=eq~~channel~~release" \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -24,18 +24,14 @@ param_ports:
   - {external_port: "8080", internal_port: "8080", port_desc: "Required for device communication"}
 param_usage_include_env: true
 param_env_vars:
-  - {env_var: "MONGO_USER", env_value: "unifi", desc: "Mongodb Username. Only evaluated on first run. **Special characters must be [url encoded](https://en.wikipedia.org/wiki/Percent-encoding)**."}
-  - {env_var: "MONGO_PASS", env_value: "", desc: "Mongodb Password. Only evaluated on first run. **Special characters must be [url encoded](https://en.wikipedia.org/wiki/Percent-encoding)**."}
-  - {env_var: "MONGO_HOST", env_value: "unifi-db", desc: "Mongodb Hostname. Only evaluated on first run."}
-  - {env_var: "MONGO_PORT", env_value: "27017", desc: "Mongodb Port. Only evaluated on first run."}
-  - {env_var: "MONGO_DBNAME", env_value: "unifi", desc: "Mongodb Database Name (stats DB is automatically suffixed with `_stat`). Only evaluated on first run."}
-  - {env_var: "MONGO_AUTHSOURCE", env_value: "admin", desc: "Mongodb [authSource](https://www.mongodb.com/docs/manual/reference/connection-string/#mongodb-urioption-urioption.authSource). For Atlas set to `admin`. Only evaluated on first run."}
+  - {env_var: "MONGO_URI", env_value: "unifi", desc: "MongoDB URI. Only evaluated on first run."}
+  - {env_var: "STAT_MONGO_URI", env_value: "", desc: "MongoDB stat URI. Only evaluated on first run."}
+  - {env_var: "MONGO_DBNAME", env_value: "unifi", desc: "MongoDB Database Name (stats DB is automatically suffixed with `_stat`). Only evaluated on first run."}
 # optional container parameters
 opt_param_usage_include_env: true
 opt_param_env_vars:
   - {env_var: "MEM_LIMIT", env_value: "1024", desc: "Optionally change the Java memory limit (in Megabytes). Set to `default` to reset to default"}
   - {env_var: "MEM_STARTUP", env_value: "1024", desc: "Optionally change the Java initial/minimum memory (in Megabytes). Set to `default` to reset to default"}
-  - {env_var: "MONGO_TLS", env_value: "", desc: "Mongodb enable [TLS](https://www.mongodb.com/docs/manual/reference/connection-string/#mongodb-urioption-urioption.tls). Only evaluated on first run."}
 opt_param_usage_include_ports: true
 opt_param_ports:
   - {external_port: "1900", internal_port: "1900/udp", port_desc: "Required for `Make controller discoverable on L2 network` option"}
@@ -182,6 +178,7 @@ init_diagram: |
   "unifi-network-application:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "20.04.26:", desc: "Change environment variables"}
   - {date: "20.04.26:", desc: "Bump JRE to v25 to support v10.3+ of the application."}
   - {date: "20.10.25:", desc: "Switch to using FW API endpoint for version checks."}
   - {date: "08.05.25:", desc: "Update sample `init-mongo.sh` for compatibility with 9.1.120 (only affects new installs)."}

--- a/root/defaults/system.properties
+++ b/root/defaults/system.properties
@@ -41,6 +41,6 @@
 # unifi.throughput.port=6789
 #
 db.mongo.local=false
-db.mongo.uri=mongodb://~MONGO_USER~:~MONGO_PASS~@~MONGO_HOST~:~MONGO_PORT~/~MONGO_DBNAME~?tls=~MONGO_TLS~~MONGO_AUTHSOURCE~
-statdb.mongo.uri=mongodb://~MONGO_USER~:~MONGO_PASS~@~MONGO_HOST~:~MONGO_PORT~/~MONGO_DBNAME~_stat?tls=~MONGO_TLS~~MONGO_AUTHSOURCE~
-unifi.db.name=~MONGO_DBNAME~
+db.mongo.uri=$MONGO_URI
+statdb.mongo.uri=$STAT_MONGO_URI
+unifi.db.name=$MONGO_DBNAME

--- a/root/etc/s6-overlay/s6-rc.d/init-unifi-network-application-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-unifi-network-application-config/run
@@ -28,39 +28,11 @@ if [[ ! -L "/usr/lib/unifi/run" ]]; then
 fi
 
 if [[ ! -e /config/data/system.properties ]]; then
-    if [[ -z "${MONGO_HOST}" ]]; then
-        echo "*** No MONGO_HOST set, cannot configure database settings. ***"
+    if [[ -z "${MONGO_URI}" || -z "${STAT_MONGO_URI}" || -z "${MONGO_DBNAME}" ]]; then
+        echo "*** Required environment variables are not set, cannot configure database settings. ***"
         sleep infinity
     else
-        echo "*** Waiting for MONGO_HOST ${MONGO_HOST} to be reachable. ***"
-        DBCOUNT=0
-        while true; do
-            if nc -w1 "${MONGO_HOST}" "${MONGO_PORT}" >/dev/null 2>&1; then
-                break
-            fi
-            DBCOUNT=$((DBCOUNT+1))
-            if [[ ${DBCOUNT} -gt 6 ]]; then
-                echo "*** Defined MONGO_HOST ${MONGO_HOST} is not reachable, cannot proceed. ***"
-                sleep infinity
-            fi
-            sleep 5
-        done
-        sed -i "s/~MONGO_USER~/${MONGO_USER}/" /defaults/system.properties
-        sed -i "s/~MONGO_HOST~/${MONGO_HOST}/" /defaults/system.properties
-        sed -i "s/~MONGO_PORT~/${MONGO_PORT}/" /defaults/system.properties
-        sed -i "s/~MONGO_DBNAME~/${MONGO_DBNAME}/" /defaults/system.properties
-        sed -i "s/~MONGO_PASS~/${MONGO_PASS}/" /defaults/system.properties
-        if [[ "${MONGO_TLS,,}" = "true" ]]; then
-            sed -i "s/~MONGO_TLS~/true/" /defaults/system.properties
-        else
-            sed -i "s/~MONGO_TLS~/false/" /defaults/system.properties
-        fi
-        if [[ -z "${MONGO_AUTHSOURCE}" ]]; then
-            sed -i "s/~MONGO_AUTHSOURCE~//" /defaults/system.properties
-        else
-            sed -i "s/~MONGO_AUTHSOURCE~/\&authSource=${MONGO_AUTHSOURCE}/" /defaults/system.properties
-        fi
-        cp /defaults/system.properties /config/data
+        envsubst < /defaults/system.properties > /config/data/system.properties
     fi
 fi
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-unifi-network-application/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Use `envsubst` tool to replace placeholders in `system.properties` file

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
- less environment variables are required. No need to specify `MONGO_AUTHSOURCE`, `MONGO_TLS` etc
- possibility to set any MongoDB URL e.g. `mongo://user:pass@localhost:27017/my-unifi-db?option=value` or for MongoDB Atlas`mongodb+srv://unifi-user:password-goes-here@unifi.mongodb.net/unifi?retryWrites=true&w=majority&appName=unifi`
- possibility to use MongoDB Atlas

**Cons:** no check if MongoDB is alive.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with the following steps on MacOS 14 (Intel):
1. create free MongoDB Atlas instance.
1. create a database user with read+write permissions to any DB in the cluster
1. `docker build -t unifi .`
1. ```docker run --name unifi -p 8443:8443 -e MONGO_URI="mongodb+srv://unifi:password@unifi.mongodb.net/unifi?retryWrites=true&w=majority&appName=unifi" -e STAT_MONGO_URI="mongodb+srv://unifi:password@unifi.mongodb.net/unifi-stats?retryWrites=true&w=majority&appName=unifi" -e MONGO_DBNAME=unifi unifi```
5. open https://0.0.0.0:8443/setup/ in browser
6. check if both `unifi` and `unifi_stat` DBs are created in MongoDB cluster

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
