### PR TITLE
Account for older MongoDB Versions

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -64,31 +64,63 @@ app_setup_block: |
   Starting with version 8.1 of Unifi Network Application, mongodb 3.6 through 7.0 are supported.
 
   **Make sure you pin your database image version and do not use `latest`, as mongodb does not support automatic upgrades between major versions.**
+  
+  **MongoDB >4.4 on X86_64 Hardware needs a CPU with AVX support. Some lower end Intel CPU models like Celeron and Pentium (before Tiger-Lake) more Details: [Advanced Vector Extensions - Wikipedia](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#CPUs_with_AVX) don't support AVX, but you can still use MongoDB 4.4.**
 
-  If you are using the [official mongodb container](https://hub.docker.com/_/mongo/), you can create your user using an `init-mongo.js` file with the following contents:
+  If you are using the [official mongodb container](https://hub.docker.com/_/mongo/) in Version 6 and up, you can create your user using an `init-mongo.js` file with the following contents:
 
   ```js
   db.getSiblingDB("MONGO_DBNAME").createUser({user: "MONGO_USER", pwd: "MONGO_PASS", roles: [{role: "dbOwner", db: "MONGO_DBNAME"}]});
   db.getSiblingDB("MONGO_DBNAME_stat").createUser({user: "MONGO_USER", pwd: "MONGO_PASS", roles: [{role: "dbOwner", db: "MONGO_DBNAME_stat"}]});
   ```
+  
+  If you are using mongodb < 6.0 and below, you can create a `init-mongo.sh` file with the following contents:
+  ```sh
+  #!/bin/bash
+
+  mongo <<EOF
+  use admin
+  db.auth("${MONGO_INITDB_ROOT_USERNAME}", "${MONGO_INITDB_ROOT_PASSWORD}")
+  use ${MONGO_DBNAME}
+  db.createUser({
+    user: "${MONGO_USER}",
+    pwd: "${MONGO_PASS}",
+    roles: [
+      { db: "${MONGO_DBNAME}", role: "dbOwner" },
+      { db: "${MONGO_DBNAME}_stat", role: "dbOwner" }
+    ]
+  })
+  EOF
+  ```
 
   Being sure to replace the placeholders with the same values you supplied to the Unifi container, and mount it into your *mongodb* container.
 
   For example:
+    MongoDB >= 6.0 and up:
+    ```yaml
+      unifi-db:
+        image: docker.io/mongo:<version tag>
+        container_name: unifi-db
+        volumes:
+          - /path/to/data:/data/db
+          - /path/to/init-mongo.js:/docker-entrypoint-initdb.d/init-mongo.js:ro
+        restart: unless-stopped
+    ```
+    MongoDB < 6.0:
+    ```yaml
+      unifi-db:
+        image: docker.io/mongo:<version tag>
+        container_name: unifi-db
+        volumes:
+          - /path/to/data:/data/db
+          - /path/to/init-mongo.sh:/docker-entrypoint-initdb.d/init-mongo.sh:ro
+        restart: unless-stopped
+    ```
+  
 
-  ```yaml
-    unifi-db:
-      image: docker.io/mongo:<version tag>
-      container_name: unifi-db
-      volumes:
-        - /path/to/data:/data/db
-        - /path/to/init-mongo.js:/docker-entrypoint-initdb.d/init-mongo.js:ro
-      restart: unless-stopped
-  ```
+  *Note that the init script method will only work on first run. If you start the Mongodb container without an init script it will generate test data automatically and you will have to manually create your databases, or restart with a clean `/data/db` volume and an init script mounted.*
 
-  *Note that the init script method will only work on first run. If you start the mongodb container without an init script it will generate test data automatically and you will have to manually create your databases, or restart with a clean `/data/db` volume and an init script mounted.*
-
-  *If you are using the init script method do not also set `MONGO_INITDB_ROOT_USERNAME`, `MONGO_INITDB_ROOT_PASSWORD`, or any other "INITDB" values as they will cause conflicts.*
+  *If you are using the init JS method do not also set `MONGO_INITDB_ROOT_USERNAME`, `MONGO_INITDB_ROOT_PASSWORD`, or any other "INITDB" values as they will cause conflicts. Setting these variables for the .sh file is necessary*
 
   You can also run the commands directly against the database using either `mongo` (< 6.0) or `mongosh` (>= 6.0).
 

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -67,14 +67,14 @@ app_setup_block: |
   
   **MongoDB >4.4 on X86_64 Hardware needs a CPU with AVX support. Some lower end Intel CPU models like Celeron and Pentium (before Tiger-Lake) more Details: [Advanced Vector Extensions - Wikipedia](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#CPUs_with_AVX) don't support AVX, but you can still use MongoDB 4.4.**
 
-  If you are using the [official mongodb container](https://hub.docker.com/_/mongo/) in Version 6 and up, you can create your user using an `init-mongo.js` file with the following contents:
+  If you are using the [official mongodb container](https://hub.docker.com/_/mongo/) in Version >=6, you can create your user using an `init-mongo.js` file with the following contents:
 
   ```js
   db.getSiblingDB("MONGO_DBNAME").createUser({user: "MONGO_USER", pwd: "MONGO_PASS", roles: [{role: "dbOwner", db: "MONGO_DBNAME"}]});
   db.getSiblingDB("MONGO_DBNAME_stat").createUser({user: "MONGO_USER", pwd: "MONGO_PASS", roles: [{role: "dbOwner", db: "MONGO_DBNAME_stat"}]});
   ```
   
-  If you are using mongodb < 6.0 and below, you can create a `init-mongo.sh` file with the following contents:
+  If you are using mongodb < 6.0, you can create a `init-mongo.sh` file with the following contents:
   ```sh
   #!/bin/bash
 
@@ -96,7 +96,7 @@ app_setup_block: |
   Being sure to replace the placeholders with the same values you supplied to the Unifi container, and mount it into your *mongodb* container.
 
   For example:
-    MongoDB >= 6.0 and up:
+    MongoDB >= 6.0:
     ```yaml
       unifi-db:
         image: docker.io/mongo:<version tag>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-unifi-network-application/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Some CPUs used in Thinclients like the Intel® Celeron® J4105 don't support AVX Instructions at all. This makes them unable to run MongoDB >4.4.X. But older MongoDB Versions don't seem to support "init-mongodb.js" files for configuring Mongodb. They need a shellscript.
I added the one I created and used, probably not perfect, but it works 😄.

## Benefits of this PR and context:
Fixes Issue #83 for my setup.
A "init-mongodb.js" will be ignored and DB Connections are not possible.

## How Has This Been Tested?
This exact script ran fine on my Thinclient 🤷 