### PR TITLE
fix init-mongo.sh

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -75,9 +75,9 @@ app_setup_block: |
     mongo_init_bin='mongo'
   fi
   "${mongo_init_bin}" <<EOF
-  use "{MONGO_AUTHSOURCE}"
+  use ${MONGO_AUTHSOURCE}
   db.auth("${MONGO_INITDB_ROOT_USERNAME}", "${MONGO_INITDB_ROOT_PASSWORD}")
-  use "${MONGO_DBNAME}"
+  use ${MONGO_DBNAME}
   db.createUser({
     user: "${MONGO_USER}",
     pwd: "${MONGO_PASS}",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The updated `init-mongo.sh` is broken.

the variable `MONGO_AUTHSOURCE` lacks the $ sign making it a usable variable
the verb `use` in MongoDB does not support double quoting the DB name

As per https://github.com/linuxserver/docker-unifi-network-application/pull/108#issuecomment-2283883486 applying the fix to `readme-vars.yaml` template. @thespad let me know if anything else is missing.

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [ ] I have read the [contributing](https://github.com/linuxserver/docker-unifi-network-application/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

## How Has This Been Tested?
Pull latest MongoDB 7.0.12, and run it with the init script provided in this repo on main branch.
The unifi-db logs will gives some details on the error, executing once more the init script will reveal all that is wrong.
```
root@9dabf25a221d:/docker-entrypoint-initdb.d# bash init-mongo.sh
Current Mongosh Log ID:	66b9e3ef84b242a13b149f47
Connecting to:		mongodb://127.0.0.1:27017/?directConnection=true&serverSelectionTimeoutMS=2000&appName=mongosh+2.2.10
Using MongoDB:		7.0.12
Using Mongosh:		2.2.10

For mongosh info see: https://docs.mongodb.com/mongodb-shell/

test> use "{MONGO_AUTHSOURCE}"
MongoshInvalidInputError: [COMMON-10001] Invalid database name: "{MONGO_AUTHSOURCE}"
test> db.auth("root", "[SNIP]")
MongoServerError[AuthenticationFailed]: Authentication failed.
test> use "unifi"
MongoshInvalidInputError: [COMMON-10001] Invalid database name: "unifi"
test> db.createUser({
...   user: "unifi",
...   pwd: "[SNIP]",
...   roles: [
...     { db: "unifi", role: "dbOwner" },
...     { db: "unifi_stat", role: "dbOwner" }
...   ]
... })
MongoServerError[Unauthorized]: Command createUser requires authentication
```


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
