### PR TITLE
Fix init-mongo.sh

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -77,7 +77,6 @@ app_setup_block: |
   "${mongo_init_bin}" <<EOF
   use ${MONGO_AUTHSOURCE}
   db.auth("${MONGO_INITDB_ROOT_USERNAME}", "${MONGO_INITDB_ROOT_PASSWORD}")
-  use ${MONGO_DBNAME}
   db.createUser({
     user: "${MONGO_USER}",
     pwd: "${MONGO_PASS}",


### PR DESCRIPTION
the $MONGO_USER and $MONGO_PASS should be created against authSource, which is admin defined in $MONGO_AUTHSOURCE
