### PR TITLE
Update sample `init-mongo.sh` for compatibility with 9.1.120 (only affects new installs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ db.createUser({
   pwd: "${MONGO_PASS}",
   roles: [
     { db: "${MONGO_DBNAME}", role: "dbOwner" },
-    { db: "${MONGO_DBNAME}_stat", role: "dbOwner" }
+    { db: "${MONGO_DBNAME}_stat", role: "dbOwner" },
+    { db: "${MONGO_DBNAME}_audit", role: "dbOwner" }
   ]
 })
 EOF
@@ -418,6 +419,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **08.05.25:** - Update sample `init-mongo.sh` for compatibility with 9.1.120 (only affects new installs).
 * **13.02.25:** - Revert JRE to 17.
 * **12.02.25:** - Bump JRE to 21.
 * **11.08.24:** - **Important**: The mongodb init instructions have been updated to enable auth ([RBAC](https://www.mongodb.com/docs/manual/core/authorization/#role-based-access-control)). We have been notified that if RBAC is not enabled, the official mongodb container allows remote access to the db contents over port 27017 without credentials. If you set up the mongodb container with the old instructions we provided, you should not map or expose port 27017. If you would like to enable auth, the easiest way is to create new instances of both unifi and mongodb with the new instructions and restore unifi from a backup.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -78,7 +78,8 @@ app_setup_block: |
     pwd: "${MONGO_PASS}",
     roles: [
       { db: "${MONGO_DBNAME}", role: "dbOwner" },
-      { db: "${MONGO_DBNAME}_stat", role: "dbOwner" }
+      { db: "${MONGO_DBNAME}_stat", role: "dbOwner" },
+      { db: "${MONGO_DBNAME}_audit", role: "dbOwner" }
     ]
   })
   EOF
@@ -178,6 +179,7 @@ init_diagram: |
   "unifi-network-application:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "08.05.25:", desc: "Update sample `init-mongo.sh` for compatibility with 9.1.120 (only affects new installs)."}
   - {date: "13.02.25:", desc: "Revert JRE to 17."}
   - {date: "12.02.25:", desc: "Bump JRE to 21."}
   - {date: "11.08.24:", desc: "**Important**: The mongodb init instructions have been updated to enable auth ([RBAC](https://www.mongodb.com/docs/manual/core/authorization/#role-based-access-control)). We have been notified that if RBAC is not enabled, the official mongodb container allows remote access to the db contents over port 27017 without credentials. If you set up the mongodb container with the old instructions we provided, you should not map or expose port 27017. If you would like to enable auth, the easiest way is to create new instances of both unifi and mongodb with the new instructions and restore unifi from a backup."}


### PR DESCRIPTION
closes #148 