### PR TITLE
Allow for customized self signed cert

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-unifi-network-application-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-unifi-network-application-config/run
@@ -30,7 +30,7 @@ fi
 if [[ ! -e /config/data/system.properties ]]; then
     if [[ -z "${MONGO_HOST}" ]]; then
         echo "*** No MONGO_HOST set, cannot configure database settings. ***"
-        sleep infinity
+        exit 255
     else
         echo "*** Waiting for MONGO_HOST ${MONGO_HOST} to be reachable. ***"
         DBCOUNT=0
@@ -41,7 +41,7 @@ if [[ ! -e /config/data/system.properties ]]; then
             DBCOUNT=$((DBCOUNT+1))
             if [[ ${DBCOUNT} -gt 6 ]]; then
                 echo "*** Defined MONGO_HOST ${MONGO_HOST} is not reachable, cannot proceed. ***"
-                sleep infinity
+                exit 255
             fi
             sleep 5
         done
@@ -64,11 +64,20 @@ if [[ ! -e /config/data/system.properties ]]; then
     fi
 fi
 
-# generate key
+# configure keystore
 if [[ ! -f /config/data/keystore ]]; then
-    keytool -genkey -keyalg RSA -alias unifi -keystore /config/data/keystore \
-    -storepass aircontrolenterprise -keypass aircontrolenterprise -validity 3650 \
-    -keysize 4096 -dname "cn=unifi" -ext san=dns:unifi
+    if [[ -f /certs/keystore.jks ]]; then
+        echo "*** DETECTED certificate, adding to keystore, not generating unique ***"
+
+        keytool -importkeystore -srckeystore /certs/keystore.jks -srcstoretype JKS -srcstorepass aircontrolenterprise -destkeystore /config/data/keystore -deststoretype PKCS12 -storepass aircontrolenterprise
+
+        echo "*** Certificate inserted ***"
+    else
+        # generate key
+        keytool -genkey -keyalg RSA -alias unifi -keystore /config/data/keystore \
+        -storepass aircontrolenterprise -keypass aircontrolenterprise -validity 3650 \
+        -keysize 4096 -dname "cn=unifi" -ext san=dns:unifi
+    fi 
 fi
 
 # permissions

--- a/root/etc/s6-overlay/s6-rc.d/init-unifi-network-application-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-unifi-network-application-config/run
@@ -30,7 +30,7 @@ fi
 if [[ ! -e /config/data/system.properties ]]; then
     if [[ -z "${MONGO_HOST}" ]]; then
         echo "*** No MONGO_HOST set, cannot configure database settings. ***"
-        exit 255
+        sleep infinity
     else
         echo "*** Waiting for MONGO_HOST ${MONGO_HOST} to be reachable. ***"
         DBCOUNT=0
@@ -41,7 +41,7 @@ if [[ ! -e /config/data/system.properties ]]; then
             DBCOUNT=$((DBCOUNT+1))
             if [[ ${DBCOUNT} -gt 6 ]]; then
                 echo "*** Defined MONGO_HOST ${MONGO_HOST} is not reachable, cannot proceed. ***"
-                exit 255
+                sleep infinity
             fi
             sleep 5
         done


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

#### Before submitting a pull request please check the following
- [x] If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR
    * This is not a fix for a typo.

- [x] Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/
    * I think this modification is something the whole userbase could benefit from, giving more flexibility inside the container itself without having to copy pasta the entire init script for a docker mod to work.
- [x] That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message  
    * It does not address an existing issue, but it does come out of the want to specify a self signed certificate so a reverse proxy can use that to encrypt the traffic between the two applications.
- [x] I have read the [contributing](https://github.com/linuxserver/docker-unifi-network-application/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
On the first initialization of the unifi network application via this application, it checks to see if there is a mounted keystore.jks file if there is, the script will proceed to importing that jks into the keystore. Rather then auto generating a unique key that is pretty hard to modify once the container is created if using kubernetes, or a different certificate that wasn't generated.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
The benefits of this PR are in my opinion allow for no hack arounds to occur to get this to work with a reverse proxy that isn't traefik and encrypt the traffic via tls from the proxy to the controller.
This allows users to bring their own certificates as long as they are signed appropriately and will work with unifi.
An example of this is cert-manager.

```yaml
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: self-signed-svc-cert
spec:
  dnsNames:
    - {your-domain-name}
  secretName: unifi-signed-cert
  commonName: unifi
  issuerRef:
    name: self-signed-ca-issuer
    kind: ClusterIssuer
    group: cert-manager.io
  keystores:
    jks:
      alias: unifi
      create: true
      # This is really just aircontrolenterprise as it has to be.
      passwordSecretRef:
        name: unifi-keystore
        key: password
```

This allows the user to create a self signed certificate that allows them to use this on a reverse proxy application for example. NGINX that is using the gatewapi implementation `BackendTLSPolicy`.

This is largely because there is no way at all to turn off insecure ski verfication for some ingress implementations.
https://docs.linuxserver.io/images/docker-unifi-network-application/#strict-reverse-proxies

This solves this problem altogether.
https://docs.linuxserver.io/images/docker-unifi-network-application/#strict-reverse-proxies

Users can now bring their own certificate and not have to worry about configuring it after the fact.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual validation in Kubernetes with cert-manager:

1. Deployed cert-manager and created a `Certificate` resource (example above) with `secretName: unifi-signed-cert` and JKS keystore output enabled.
2. Verified the `unifi-signed-cert` secret was created by cert-manager.
3. Mounted that secret into the UniFi container as a volume:

In Kubernetes looks like this
```yaml
pod:
  spec:
    containers:
      volumeMounts:
        - name: certs-vol
          mountPath: /certs
          readOnly: true
    volumes:
    - name: certs-vol
      secret:
        secretName: unifi-signed-cert
```

4. Redeployed the workload and confirmed UniFi started successfully using the mounted keystore/certificate instead of requiring post-start certificate replacement.
5. Verified reverse-proxy-to-UniFi TLS works with the provided certificate.

------------------------------

### Post Change 

I have been running this in my homelab now with a pretty complicated unifi setup and have had no issues since, running behind a nginx proxy.

## Updates to Documentation

* In order for a user to import at the start of a initial container, they need to mount the certificate on the container too `/certs/keystore.jks`.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
* https://github.com/linuxserver/docker-unifi-network-application/issues/78
* https://github.com/nginx/nginx-gateway-fabric/pull/3084 (also the reason why I had to go through this amount of effort)
