### PR TITLE
Add dbOwner role for _restore database to mongo-init.sh script

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -77,6 +77,7 @@ app_setup_block: |
     user: "${MONGO_USER}",
     pwd: "${MONGO_PASS}",
     roles: [
+      "clusterMonitor",
       { db: "${MONGO_DBNAME}", role: "dbOwner" },
       { db: "${MONGO_DBNAME}_stat", role: "dbOwner" },
       { db: "${MONGO_DBNAME}_audit", role: "dbOwner" },

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -79,7 +79,8 @@ app_setup_block: |
     roles: [
       { db: "${MONGO_DBNAME}", role: "dbOwner" },
       { db: "${MONGO_DBNAME}_stat", role: "dbOwner" },
-      { db: "${MONGO_DBNAME}_audit", role: "dbOwner" }
+      { db: "${MONGO_DBNAME}_audit", role: "dbOwner" },
+      { db: "${MONGO_DBNAME}_restore", role: "dbOwner" }
     ]
   })
   EOF


### PR DESCRIPTION
- [x] I have read the [contributing](https://github.com/linuxserver/docker-unifi-network-application/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------
## Description:
When restoring an installation from backup, the unifi network application tries to drop the `${MONGODB_DBNAME}_restore` database, which fails because the user used to authenticate with MonboDB doesn't have the permissions to do so.

## Benefits of this PR and context:
By adding ownership to the `${MONGODB_DBNAME}_restore` database, the restore-from-backup functionality should work.

## How Has This Been Tested?
Unfortunately, I had do a fresh installation of the Unifi network application, and when trying to restore from backup, nothing happened.
The logs showed me that the application was unauthorized to drop the `${MONGODB_DBNAME}_restore` database:
```
[2026-02-16T13:41:12,499Z] <webapi-3> ERROR db     - Unable to import database
com.mongodb.MongoCommandException: Command failed with error 13 (Unauthorized): 'not authorized on unifi_restore to execute command { dropDatabase: 1, $db: "unifi_restore", lsid: { id: UUID("31e790c4-22f3-42d1-94ae-db5a8dd862f2") } }' on server unifi-db:27017. The full response is {"ok": 0.0, "errmsg": "not authorized on unifi_restore to execute command { dropDatabase: 1, $db: \"unifi_restore\", lsid: { id: UUID(\"31e790c4-22f3-42d1-94ae-db5a8dd862f2\") } }", "code": 13, "codeName": "Unauthorized"}
        at com.mongodb.internal.connection.ProtocolHelper.getCommandFailureException(ProtocolHelper.java:205)
        at com.mongodb.internal.connection.InternalStreamConnection.receiveCommandMessageResponse(InternalStreamConnection.java:515)
        at com.mongodb.internal.connection.InternalStreamConnection.sendAndReceiveInternal(InternalStreamConnection.java:438)
        at com.mongodb.internal.connection.InternalStreamConnection.lambda$sendAndReceive$0(InternalStreamConnection.java:366)
        at com.mongodb.internal.connection.InternalStreamConnection.sendAndReceive(InternalStreamConnection.java:369)
        at com.mongodb.internal.connection.UsageTrackingInternalConnection.sendAndReceive(UsageTrackingInternalConnection.java:114)
        at com.mongodb.internal.connection.DefaultConnectionPool$PooledConnection.sendAndReceive(DefaultConnectionPool.java:743)
        at com.mongodb.internal.connection.CommandProtocolImpl.execute(CommandProtocolImpl.java:76)
        at com.mongodb.internal.connection.DefaultServer$DefaultServerProtocolExecutor.execute(DefaultServer.java:209)
        at com.mongodb.internal.connection.DefaultServerConnection.executeProtocol(DefaultServerConnection.java:115)
        at com.mongodb.internal.connection.DefaultServerConnection.command(DefaultServerConnection.java:83)
        at com.mongodb.internal.connection.DefaultServerConnection.command(DefaultServerConnection.java:74)
        at com.mongodb.internal.connection.DefaultServer$OperationCountTrackingConnection.command(DefaultServer.java:299)
        at com.mongodb.internal.operation.SyncOperationHelper.executeCommand(SyncOperationHelper.java:207)
        at com.mongodb.internal.operation.DropDatabaseOperation.lambda$execute$0(DropDatabaseOperation.java:65)
        at com.mongodb.internal.operation.SyncOperationHelper.withConnectionSource(SyncOperationHelper.java:160)
        at com.mongodb.internal.operation.SyncOperationHelper.withConnection(SyncOperationHelper.java:105)
        at com.mongodb.internal.operation.DropDatabaseOperation.execute(DropDatabaseOperation.java:64)
        at com.mongodb.internal.operation.DropDatabaseOperation.execute(DropDatabaseOperation.java:45)
        at com.mongodb.client.internal.MongoClientDelegate$DelegateOperationExecutor.execute(MongoClientDelegate.java:173)
        at com.mongodb.client.internal.MongoDatabaseImpl.executeDrop(MongoDatabaseImpl.java:211)
        at com.mongodb.client.internal.MongoDatabaseImpl.drop(MongoDatabaseImpl.java:201)
        at com.ubnt.service.system.vjkQiFI.KDAhaqZDGbqZ(Unknown Source)
        at com.ubnt.service.system.vjkQiFI.bWwgIOQmUuYLRTvbHC(Unknown Source)
        at com.ubnt.service.system.vjkQiFI.bskior(Unknown Source)
        at com.ubnt.service.system.vjkQiFI.KDAhaqZDGbqZ(Unknown Source)
        at com.ubnt.service.system.c.b.BKeAvbb.KDAhaqZDGbqZ(Unknown Source)
        at com.ubnt.service.system.c.b.BKeAvbb.KDAhaqZDGbqZ(Unknown Source)
        at com.ubnt.service.system.c.b.kAcSmtBQgHqJVXE.KDAhaqZDGbqZ(Unknown Source)
        at com.ubnt.service.system.c.b.kAcSmtBQgHqJVXE.KDAhaqZDGbqZ(Unknown Source)
        at com.ubnt.service.system.c.urbKkFPuEqsafVIUykG.bWwgIOQmUuYLRTvbHC(Unknown Source)
        at com.ubnt.service.system.c.urbKkFPuEqsafVIUykG.KDAhaqZDGbqZ(Unknown Source)
        at com.ubnt.service.system.e.a.FNqpDUHct.KDAhaqZDGbqZ(Unknown Source)
        at com.ubnt.ace.api.urbKkFPuEqsafVIUykG.KDAhaqZDGbqZ(Unknown Source)
        at com.ubnt.ace.api.quyuUdnLtTw.bskior(Unknown Source)
        at com.ubnt.ace.api.ApiServlet.service(Unknown Source)
        at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:658)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:138)
        at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:51)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:162)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:138)
        at org.springframework.web.filter.RequestContextFilter.doFilterInternal(RequestContextFilter.java:100)
        at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:162)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:138)
        at com.ubnt.service.trace.h.wqGnjNIRjNio.doFilter(Unknown Source)
        at org.springframework.web.filter.DelegatingFilterProxy.invokeDelegate(DelegatingFilterProxy.java:362)
        at org.springframework.web.filter.DelegatingFilterProxy.doFilter(DelegatingFilterProxy.java:278)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:162)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:138)
        at com.ubnt.ace.view.AuthFilter.KDAhaqZDGbqZ(Unknown Source)
        at com.ubnt.ace.view.AuthFilter.doFilter(Unknown Source)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:162)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:138)
        at com.ubnt.ace.view.UbiosHttpsFilter.doFilter(Unknown Source)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:162)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:138)
        at org.apache.catalina.filters.CorsFilter.handleNonCORS(CorsFilter.java:332)
        at org.apache.catalina.filters.CorsFilter.doFilter(CorsFilter.java:159)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:162)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:138)
        at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:165)
        at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:88)
        at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:482)
        at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:113)
        at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:83)
        at ch.qos.logback.access.tomcat.LogbackValve.invoke(LogbackValve.java:268)
        at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:72)
        at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:342)
        at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:399)
        at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:63)
        at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:903)
        at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1774)
        at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:52)
        at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:973)
        at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:491)
        at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:63)
        at java.base/java.lang.Thread.run(Thread.java:840)
[2026-02-16T13:41:12,500Z] <webapi-3> ERROR db     - Failed to import config database during backup restore
[2026-02-16T13:41:12,562Z] <webapi-3> WARN  system - Failed to restore backup. Database may be corrupted.
...
[2026-02-16T13:41:12,559Z] <webapi-3> ERROR system - Failed to import backup. No changes were applied.
[2026-02-16T13:41:12,561Z] <webapi-3> ERROR system - Fail to restore
```

## Source / References:

